### PR TITLE
Update the script to include the assignment of projectID from the third argument

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,7 @@
 # Input args
 profile=$1 
 outDir=$2
+projectID=$3  # Assign projectID from the third argument
 
 # housekeeping
 if [[ -z $outDir || -z $profile || -z $projectID ]]; then echo "All variables are required: profile outDir projectID"; exit; fi


### PR DESCRIPTION
### Description
This PR resolves the issue of the missin projectID.

The issue occurred because the projectID variable was not passed as an input argument to the script. This fix ensures that projectID is included in the script's input arguments.

### Changes Made

Updated the run.sh script to include projectID as the third input argument.

### Updated Script Snippet

```
# Input args
profile=$1
outDir=$2
projectID=$3

```

Related Issue
[https://github.com/bhanugandham/2025_BINFdev/issues/1]

