### PR TITLE
provision in command-line arguments for accepting an input samplesheet and projectID in config file

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
 
     // Input options
     input                      = null
-    projectID                  = null
+    projectID                  = "testprojid"
 
     // References
     genome                     = null

--- a/run.sh
+++ b/run.sh
@@ -4,16 +4,18 @@
 
 # Input args
 profile=$1 
-outDir=$2
-projectID=$3  # Assign projectID from the third argument
+input=$2
+outDir=$3
+projectID=$4  # Assign projectID from the third argument
 
-# housekeeping
-if [[ -z $outDir || -z $profile || -z $projectID ]]; then echo "All variables are required: profile outDir projectID"; exit; fi
+# housekeeping; add input condition in the if statement
+if [[ -z $outDir || -z $profile || -z $projectID || -z $input ]]; then echo "All variables are required: profile input outDir projectID"; exit; fi
 if [[ ! -d $outDir ]]; then mkdir -p $outDir; fi
 
 # run the workflow
 nextflow run main.nf \
 	-profile $profile \
+	--input $input \
 	--outdir $outDir \
  	--projectID $projectID \
 	-resume


### PR DESCRIPTION
### Description
This PR resolves the issue of the missing input samplesheet and null projectID in config file.

The issue occurred because the inout variable was not passed as an input argument to the bash script. This fix ensures that inout is included in the script's input arguments. Additionally, projectID is a required field and therefore its default value in the config file has been updated. 

### Changes Made

Updated the run.sh script to include inout as an input argument and projectID in the config file now has a default value that is not null.

Related Issue
[https://github.com/bhanugandham/2025_BINFdev/issues/3]

