### PR TITLE
changed process label from low to medium for fastqc

### DIFF
--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -1,6 +1,6 @@
 process FASTQC {
     tag "$meta.id"
-    label 'process_low'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
### Goal:
To change the resource allocation of the fastqc module to have the following, pre-defined resources: cpus = { check_max( 6 * task.attempt, 'cpus' ) } memory = { check_max( 36.GB * task.attempt, 'memory' ) } time = { check_max( 8.h * task.attempt, 'time' ) }

### Method/Changes made:
changed process label from process_low to process_medium in the fastqc module's main.nf, in order to re-use the labels and to keep the same label naming convention.

### Related Issue
[https://github.com/https://github.com/bhanugandham/2025_BINFdev/issues/6]